### PR TITLE
added firebug lite detection

### DIFF
--- a/devtools-detect.js
+++ b/devtools-detect.js
@@ -15,7 +15,7 @@
 	};
 
 	setInterval(function () {
-		if (window.outerWidth - window.innerWidth > threshold ||
+		if ((window.Firebug !== undefined && window.Firebug.chrome !== undefined && window.Firebug.chrome.isInitialized) || window.outerWidth - window.innerWidth > threshold ||
 			window.outerHeight - window.innerHeight > threshold) {
 			if (!devtools.open) {
 				emitEvent(true);


### PR DESCRIPTION
window.Firebug.chrome.isInitialized is true when firebug lite is open, tested this in chrome and ie (despite the odd object inside firebug being named chrome)
