### PR TITLE
Save reference to the initial devtools object

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,19 +33,15 @@
 				emitEvent(true, orientation);
 			}
 
-			devtools = {
-				open: true,
-				orientation: orientation
-			};
+			devtools.open = true;
+			devtools.orientation = orientation;
 		} else {
 			if (devtools.open) {
 				emitEvent(false, null);
 			}
 
-			devtools = {
-				open: false,
-				orientation: null
-			};
+			devtools.open = false;
+			devtools.orientation = null;
 		}
 	}, 500);
 


### PR DESCRIPTION
We shouldn't recreate object each time because if we want to get current status -> we couldn't because every 500 ms it's another object.