### PR TITLE
Change style attribute to an id in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 			
 			#fork-me {
 				position: absolute; top: 0; right: 0; border: 0;
+			}
 
 			.instruction {
 				font-weight: 200;

--- a/index.html
+++ b/index.html
@@ -41,9 +41,12 @@
 				height: 28px;
 				font-weight: 100;
 			}
-			
+
 			#fork-me {
-				position: absolute; top: 0; right: 0; border: 0;
+				position: absolute;
+				top: 0;
+				right: 0;
+				border: 0;
 			}
 
 			.instruction {

--- a/index.html
+++ b/index.html
@@ -41,6 +41,9 @@
 				height: 28px;
 				font-weight: 100;
 			}
+			
+			#fork-me {
+				position: absolute; top: 0; right: 0; border: 0;
 
 			.instruction {
 				font-weight: 200;
@@ -58,7 +61,7 @@
 	</head>
 	<body>
 		<a href="https://github.com/sindresorhus/devtools-detect">
-			<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub">
+			<img id="fork-me" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub">
 		</a>
 		<div class="container">
 			<section class="main span12 text-center">


### PR DESCRIPTION
Change style attribute to an id in index.html. Because the style attribute is deprecated.